### PR TITLE
Base work for Windows compatibility

### DIFF
--- a/ext/opcache/config.w32
+++ b/ext/opcache/config.w32
@@ -1,8 +1,9 @@
 ARG_ENABLE("opcache", "whether to enable Zend OPcache support", "yes");
 
-/* var PHP_OPCACHE_PGO = false; */
 
 if (PHP_OPCACHE != "no") {
+
+	ARG_ENABLE("opcache-jit", "whether to enable JIT", "yes");
 
 	ZEND_EXTENSION('opcache', "\
 		ZendAccelerator.c \
@@ -17,9 +18,26 @@ if (PHP_OPCACHE != "no") {
 		zend_shared_alloc.c \
 		shared_alloc_win32.c", true, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 
-	ADD_SOURCES(configure_module_dirname + "/Optimizer", "zend_optimizer.c pass1_5.c pass2.c pass3.c optimize_func_calls.c block_pass.c optimize_temp_vars_5.c nop_removal.c compact_literals.c zend_cfg.c zend_dfg.c dfa_pass.c zend_ssa.c zend_inference.c zend_func_info.c zend_call_graph.c sccp.c scdf.c dce.c escape_analysis.c compact_vars.c zend_dump.c", "opcache", "OptimizerObj");
+	if (PHP_OPCACHE_JIT == "yes") {
+		if (CHECK_HEADER_ADD_INCLUDE("dynasm/dasm_x86.h", "CFLAGS_OPCACHE", PHP_OPCACHE + ";ext\\opcache\\jit")) {
+			var dasm_flags = X64 ? "-D X64=1" : "";
+			DEFINE("DASM_FLAGS", dasm_flags);
 
+			AC_DEFINE('HAVE_JIT', 1, 'Define to enable JIT');
+			/* XXX read this dynamically */
+			/*ADD_FLAG("CFLAGS_OPCACHE", "/D DASM_VERSION=10400");*/
+
+			ADD_MAKEFILE_FRAGMENT(configure_module_dirname + "\\jit\\Makefile.frag.w32");
+
+			ADD_SOURCES(configure_module_dirname + "\\jit", "zend_jit.c zend_jit_vm_helpers.c", "opcache", "opcache_jit");
+		} else {
+			WARNING("JIT not enabled, headers not found");
+		}
+	}
+
+	ADD_SOURCES(configure_module_dirname + "/Optimizer", "zend_optimizer.c pass1_5.c pass2.c pass3.c optimize_func_calls.c block_pass.c optimize_temp_vars_5.c nop_removal.c compact_literals.c zend_cfg.c zend_dfg.c dfa_pass.c zend_ssa.c zend_inference.c zend_func_info.c zend_call_graph.c zend_dump.c escape_analysis.c compact_vars.c dce.c sccp.c scdf.c", "opcache", "OptimizerObj");
 
 	ADD_FLAG('CFLAGS_OPCACHE', "/I " + configure_module_dirname);
 
 }
+

--- a/ext/opcache/jit/Makefile.frag.w32
+++ b/ext/opcache/jit/Makefile.frag.w32
@@ -1,0 +1,16 @@
+$(BUILD_DIR)\\minilua.exe: ext\opcache\jit\dynasm\minilua.c
+	@if exist $(BUILD_DIR)\\minilua.exe del $(BUILD_DIR)\\minilua.exe
+	$(PHP_CL) /Fo$(BUILD_DIR)\ /Fd$(BUILD_DIR)\ /Fp$(BUILD_DIR)\ /FR$(BUILD_DIR) /Fe$(BUILD_DIR)\minilua.exe ext\opcache\jit\dynasm\minilua.c
+
+ext\opcache\jit\zend_jit_x86.c: $(BUILD_DIR)\\minilua.exe
+	@if exist ext\opcache\jit\zend_jit_x86.c del ext\opcache\jit\zend_jit_x86.c
+	$(BUILD_DIR)\\minilua.exe ext/opcache/jit/dynasm/dynasm.lua $(DASM_FLAGS) -o $@ ext/opcache/jit/zend_jit_x86.dasc
+
+$(BUILD_DIR)\opcache_jit\zend_jit.obj: \
+	ext/opcache/jit/zend_jit_x86.c \
+	ext/opcache/jit/zend_jit_helpers.c \
+	ext/opcache/jit/zend_jit_disasm_x86.c \
+	ext/opcache/jit/zend_jit_gdb.c \
+	ext/opcache/jit/zend_jit_perf_dump.c \
+	ext/opcache/jit/zend_jit_oprofile.c \
+	ext/opcache/jit/zend_jit_vtune.c

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -129,8 +129,10 @@ static zend_bool zend_long_is_power_of_two(zend_long x)
 #include "jit/zend_jit_helpers.c"
 #include "jit/zend_jit_x86.c"
 #include "jit/zend_jit_disasm_x86.c"
+#ifndef _WIN32
 #include "jit/zend_jit_gdb.c"
 #include "jit/zend_jit_perf_dump.c"
+#endif
 #ifdef HAVE_OPROFILE
 # include "jit/zend_jit_oprofile.c"
 #endif
@@ -147,7 +149,7 @@ static zend_bool zend_long_is_power_of_two(zend_long x)
 
 #define DASM_ALIGNMENT 16
 
-ZEND_API void zend_jit_status(zval *ret)
+ZEND_EXT_API void zend_jit_status(zval *ret)
 {
 	zval stats;
 	array_init(&stats);
@@ -2824,7 +2826,7 @@ static int zend_needs_manual_jit(const zend_op_array *op_array)
 	return 0;
 }
 
-ZEND_API int zend_jit_op_array(zend_op_array *op_array, zend_script *script)
+ZEND_EXT_API int zend_jit_op_array(zend_op_array *op_array, zend_script *script)
 {
 	if (dasm_ptr == NULL) {
 		return FAILURE;
@@ -2869,7 +2871,7 @@ ZEND_API int zend_jit_op_array(zend_op_array *op_array, zend_script *script)
 	}
 }
 
-ZEND_API int zend_jit_script(zend_script *script)
+ZEND_EXT_API int zend_jit_script(zend_script *script)
 {
 	void *checkpoint;
 	zend_call_graph call_graph;
@@ -2989,7 +2991,7 @@ jit_failure:
 	return FAILURE;
 }
 
-ZEND_API void zend_jit_unprotect(void)
+ZEND_EXT_API void zend_jit_unprotect(void)
 {
 #ifdef HAVE_MPROTECT
 	if (!(ZCG(accel_directives).jit_debug & (ZEND_JIT_DEBUG_GDB|ZEND_JIT_DEBUG_PERF_DUMP))) {
@@ -3000,7 +3002,7 @@ ZEND_API void zend_jit_unprotect(void)
 #endif
 }
 
-ZEND_API void zend_jit_protect(void)
+ZEND_EXT_API void zend_jit_protect(void)
 {
 #ifdef HAVE_MPROTECT
 	if (!(ZCG(accel_directives).jit_debug & (ZEND_JIT_DEBUG_GDB|ZEND_JIT_DEBUG_PERF_DUMP))) {
@@ -3076,7 +3078,7 @@ static int zend_jit_make_stubs(void)
 	return 1;
 }
 
-ZEND_API int zend_jit_startup(zend_long jit, size_t size)
+ZEND_EXT_API int zend_jit_startup(zend_long jit, size_t size)
 {
 	size_t page_size = jit_page_size();
 	int shared = 1;
@@ -3168,7 +3170,7 @@ ZEND_API int zend_jit_startup(zend_long jit, size_t size)
 	return SUCCESS;
 }
 
-ZEND_API void zend_jit_shutdown(void)
+ZEND_EXT_API void zend_jit_shutdown(void)
 {
 #ifdef HAVE_OPROFILE
 	if (ZCG(accel_directives).jit_debug & ZEND_JIT_DEBUG_OPROFILE) {
@@ -3199,7 +3201,7 @@ ZEND_API void zend_jit_shutdown(void)
 	}
 }
 
-ZEND_API void zend_jit_activate(void)
+ZEND_EXT_API void zend_jit_activate(void)
 {
 	if (zend_jit_trigger == ZEND_JIT_ON_HOT_COUNTERS) {
 		int i;
@@ -3210,7 +3212,7 @@ ZEND_API void zend_jit_activate(void)
 	}
 }
 
-ZEND_API void zend_jit_deactivate(void)
+ZEND_EXT_API void zend_jit_deactivate(void)
 {
 	if (zend_jit_trigger == ZEND_JIT_ON_PROF_REQUEST) {
 		if (!zend_jit_profile_counter) {
@@ -3241,38 +3243,38 @@ ZEND_API void zend_jit_deactivate(void)
 
 #else /* HAVE_JIT */
 
-ZEND_API int zend_jit_op_array(zend_op_array *op_array, zend_script *script)
+ZEND_EXT_API int zend_jit_op_array(zend_op_array *op_array, zend_script *script)
 {
 	return FAILURE;
 }
 
-ZEND_API int zend_jit_script(zend_script *script)
+ZEND_EXT_API int zend_jit_script(zend_script *script)
 {
 	return FAILURE;
 }
 
-ZEND_API void zend_jit_unprotect(void)
+ZEND_EXT_API void zend_jit_unprotect(void)
 {
 }
 
-ZEND_API void zend_jit_protect(void)
+ZEND_EXT_API void zend_jit_protect(void)
 {
 }
 
-ZEND_API int zend_jit_startup(zend_long jit, size_t size)
+ZEND_EXT_API int zend_jit_startup(zend_long jit, size_t size)
 {
 	return FAILURE;
 }
 
-ZEND_API void zend_jit_shutdown(void)
+ZEND_EXT_API void zend_jit_shutdown(void)
 {
 }
 
-ZEND_API void zend_jit_activate(void)
+ZEND_EXT_API void zend_jit_activate(void)
 {
 }
 
-ZEND_API void zend_jit_deactivate(void)
+ZEND_EXT_API void zend_jit_deactivate(void)
 {
 }
 

--- a/ext/opcache/jit/zend_jit.h
+++ b/ext/opcache/jit/zend_jit.h
@@ -75,15 +75,15 @@
 
 #define ZEND_JIT_DEBUG_GDB       (1<<8)
 
-ZEND_API int  zend_jit_op_array(zend_op_array *op_array, zend_script *script);
-ZEND_API int  zend_jit_script(zend_script *script);
-ZEND_API void zend_jit_unprotect(void);
-ZEND_API void zend_jit_protect(void);
-ZEND_API int  zend_jit_startup(zend_long jit, size_t size);
-ZEND_API void zend_jit_shutdown(void);
-ZEND_API void zend_jit_activate(void);
-ZEND_API void zend_jit_deactivate(void);
-ZEND_API void zend_jit_status(zval *ret);
+ZEND_EXT_API int  zend_jit_op_array(zend_op_array *op_array, zend_script *script);
+ZEND_EXT_API int  zend_jit_script(zend_script *script);
+ZEND_EXT_API void zend_jit_unprotect(void);
+ZEND_EXT_API void zend_jit_protect(void);
+ZEND_EXT_API int  zend_jit_startup(zend_long jit, size_t size);
+ZEND_EXT_API void zend_jit_shutdown(void);
+ZEND_EXT_API void zend_jit_activate(void);
+ZEND_EXT_API void zend_jit_deactivate(void);
+ZEND_EXT_API void zend_jit_status(zval *ret);
 
 typedef struct _zend_lifetime_interval zend_lifetime_interval;
 typedef struct _zend_life_range zend_life_range;

--- a/ext/opcache/jit/zend_jit_disasm_x86.c
+++ b/ext/opcache/jit/zend_jit_disasm_x86.c
@@ -34,7 +34,9 @@ static void zend_jit_disasm_add_symbol(const char *name,
                                        uint64_t    addr,
                                        uint64_t    size);
 
-#include "jit/zend_elf.c"
+#ifndef _WIN32
+# include "jit/zend_elf.c"
+#endif
 
 #include "zend_sort.h"
 
@@ -42,7 +44,9 @@ static void zend_jit_disasm_add_symbol(const char *name,
 # define _GNU_SOURCE
 #endif
 
+#ifndef _WIN32
 #include <dlfcn.h>
+#endif
 
 static struct ud ud;
 
@@ -211,6 +215,7 @@ static const char* zend_jit_disasm_resolver(struct ud *ud,
                                             uint64_t   addr,
                                             int64_t   *offset)
 {
+#ifndef _WIN32
 	((void)ud);
 	const char *name;
 	void *a = (void*)(zend_uintptr_t)(addr);
@@ -226,6 +231,13 @@ static const char* zend_jit_disasm_resolver(struct ud *ud,
 	 && info.dli_saddr == a) {
 		return info.dli_sname;
 	}
+#else
+	const char *name;
+	name = zend_jit_disasm_find_symbol(addr, offset);
+	if (name) {
+		return name;
+	}
+#endif
 
 	return NULL;
 }
@@ -444,7 +456,9 @@ static int zend_jit_disasm_init(void)
 	REGISTER_HELPER(zend_jit_hot_func);
 #undef  REGISTER_HELPER
 
+#ifndef _WIN32
 	zend_elf_load_symbols();
+#endif
 
 	return 1;
 }

--- a/ext/opcache/jit/zend_jit_internal.h
+++ b/ext/opcache/jit/zend_jit_internal.h
@@ -34,7 +34,11 @@ extern int16_t zend_jit_hot_counters[ZEND_HOT_COUNTERS_COUNT];
 void zend_jit_hot_func(zend_execute_data *execute_data, const zend_op *opline);
 
 /* VM handlers */
+#if HAVE_GCC_GLOBAL_REGS
 typedef void (ZEND_FASTCALL *zend_vm_opcode_handler_t)(void);
+#else
+typedef int (ZEND_FASTCALL *zend_vm_opcode_handler_t)(void);
+#endif
 
 extern const zend_op *zend_jit_halt_op;
 
@@ -43,7 +47,11 @@ void ZEND_FASTCALL zend_jit_leave_nested_func_helper(uint32_t call_info);
 void ZEND_FASTCALL zend_jit_leave_top_func_helper(uint32_t call_info);
 void ZEND_FASTCALL zend_jit_copy_extra_args_helper(void);
 void ZEND_FASTCALL zend_jit_deprecated_or_abstract_helper(void);
+#if HAVE_GCC_GLOBAL_REGS
 void ZEND_FASTCALL zend_jit_profile_helper(void);
+#else
+int ZEND_FASTCALL zend_jit_profile_helper(void);
+#endif
 void ZEND_FASTCALL zend_jit_func_counter_helper(void);
 void ZEND_FASTCALL zend_jit_loop_counter_helper(void);
 void ZEND_FASTCALL zend_jit_get_constant(const zval *key, uint32_t flags);

--- a/ext/opcache/jit/zend_jit_x86.dasc
+++ b/ext/opcache/jit/zend_jit_x86.dasc
@@ -73,7 +73,7 @@
 #include "jit/zend_jit_x86.h"
 
 const char* zend_reg_name[] = {
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(_M_X64)
 	"rax", "rcx", "rdx", "rbx", "rsp", "rbp", "rsi", "rdi",
 	"r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15",
 	"xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",
@@ -1379,7 +1379,11 @@ static void* dasm_labels[zend_lb_MAX];
 |			add r4, 4
 |		.endif
 ||#else
+||#ifdef HAVE_BUILTIN_CONSTANT_P
 |		EXT_CALL _efree_24, r0
+||#else
+|		EXT_CALL _efree, r0
+||#endif
 ||#endif
 |.endmacro
 
@@ -1408,12 +1412,17 @@ static void* dasm_labels[zend_lb_MAX];
 |			add r4, 4
 |		.endif
 ||#else
+||#ifdef HAVE_BUILTIN_CONSTANT_P
 ||	if (size == 24) {
 |		EXT_CALL _emalloc_24, r0
 ||	} else {
 |		mov FCARG1a, size
 |		EXT_CALL _emalloc, r0
 ||	}
+||#else
+|		mov FCARG1a, size
+|		EXT_CALL _emalloc, r0
+||#endif
 ||#endif
 |.endmacro
 


### PR DESCRIPTION
This includes

- catch up with config.w32 and makefile
- using `minilua` to generate the C file with JIT implementation
- surrogate implementations for __builtin_ctz/__builtin_clz
- other fixes for build without global registers, exporting symbols, etc.

The JIT functionality is still untouched, so needs to be implemented. Also the disasm functionality for dumping JIT code is excluded for now, as it would require some hand made or library code to read symbols from COFF files. Still, the changes in this patch will help to ramp up the missing functionality.

Thanks. 