### PR TITLE
Add callback that allows extensions to @nojit a function/method or file.

### DIFF
--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -30,6 +30,7 @@ BEGIN_EXTERN_C()
 struct _zend_fcall_info;
 ZEND_API extern void (*zend_execute_ex)(zend_execute_data *execute_data);
 ZEND_API extern void (*zend_execute_internal)(zend_execute_data *execute_data, zval *return_value);
+ZEND_API extern int (*zend_execute_mode_allow_leave)(zend_op_array *op_array);
 
 void init_executor(void);
 void shutdown_executor(void);

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -42,6 +42,7 @@
 
 ZEND_API void (*zend_execute_ex)(zend_execute_data *execute_data);
 ZEND_API void (*zend_execute_internal)(zend_execute_data *execute_data, zval *return_value);
+ZEND_API int (*zend_execute_mode_allow_leave)(zend_op_array *op_array);
 
 /* true globals */
 ZEND_API const zend_fcall_info empty_fcall_info = { 0, {{0}, {{0}}, {0}}, NULL, NULL, NULL, 0, 0 };

--- a/ext/opcache/jit/zend_jit.c
+++ b/ext/opcache/jit/zend_jit.c
@@ -2836,6 +2836,11 @@ ZEND_EXT_API int zend_jit_op_array(zend_op_array *op_array, zend_script *script)
 		return FAILURE;
 	}
 
+	/* skip jitting and leaving the executor mode if an extension overwriting the callback prevents it */
+	if (zend_execute_mode_allow_leave != NULL && zend_execute_mode_allow_leave(op_array) == 0) {
+		return SUCCESS;
+	}
+
 	if (zend_jit_trigger == ZEND_JIT_ON_FIRST_EXEC) {
 		zend_op *opline = op_array->opcodes;
 
@@ -2884,6 +2889,11 @@ ZEND_EXT_API int zend_jit_script(zend_script *script)
 
 	if (dasm_ptr == NULL || *dasm_ptr == dasm_end) {
 		return FAILURE;
+	}
+
+	/* skip jitting and leaving the executor mode if an extension overwriting the callback prevents it */
+	if (zend_execute_mode_allow_leave != NULL && zend_execute_mode_allow_leave(&(script->main_op_array)) == 0) {
+		return SUCCESS;
 	}
 
 	checkpoint = zend_arena_checkpoint(CG(arena));


### PR DESCRIPTION
Prototype approach for allowing extensions take part in the to JIT or Not to JIT decision that Opcache makes. This solution is a simple approach to allow profiling + instrumentation if no further tracing APIs should be added to the JIT code.

The benefit of this approach is that it allows extension full control, and has no overhead on runtime (only compile time).

Todos/Questions:
- [ ] Find a better name for the callback
- [ ] Find the correct location for the callback
- [ ] Do we need this or will there be an optional tracing API for JIT to activate and hook into. I think it make sense either way to give extensions control over the JIT decision.

The use case is extensions that want to instrument a few selected userland functions / methods to catch their arguments for very specific tracing / instrumentation via `zend_execute_ex` hook.

Examples:

1. Profiling: Instrumenting nrk/predis library to collect performance information about individual Redis operations
2. Monitoring: Instrument a frameworks controller creation to extract controller and action name for monitoring performance of an application (Login Controller took 200ms average).
3. Error Tracking: Instrument Symfonys HttpKernel::logException() method (or any other framework exception hook) to capture Exceptions that are rendered to HTTP Status 500 pages and send them to error tracking tool.

These use cases can currently be implemented as `zend_execute_ex` hook, the simplest way to reliably hook into userland function calls and looking up class and method names in a HashTable of instrumentation callbacks. Extensions risk a performance hit vs jitted methods here, but only for a very small list of functions where seeing their execution in `zend_execute_ex` is considered more important for the business / monitoring needs. Right now overhead can be as low as 1-2% for this approach, 5% for more heavy instrumentations, but in general accepted by people compared to the gain in insights.

Downside is this approach prevents stackless VM runs, which an alternative API might be better.